### PR TITLE
Initialize Slyce Session after getting camera permission

### DIFF
--- a/Examples/LensView/SlyceSDK-LensView-Demo-Java/app/src/main/java/it/slyce/slycesdk_lensview_demo_java/MainActivity.java
+++ b/Examples/LensView/SlyceSDK-LensView-Demo-Java/app/src/main/java/it/slyce/slycesdk_lensview_demo_java/MainActivity.java
@@ -112,6 +112,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (isCameraPermissionGranted()) {
+            initSlyceSession();
             initSlyceLensView();
         }
     }


### PR DESCRIPTION
Initialize Slyce Session after getting camera permission to prevent crash after first time permission is granted