### PR TITLE
Camera Preview Start/Stop Redundancy

### DIFF
--- a/Examples/Headless/SlyceSDK-Headless-Demo-Java/app/build.gradle
+++ b/Examples/Headless/SlyceSDK-Headless-Demo-Java/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation(name: 'slyce', ext: 'aar')
 
     implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.google.android.gms:play-services-ads:15.0.0'
     implementation 'com.google.android.gms:play-services-gcm:15.0.0'

--- a/Examples/Headless/SlyceSDK-Headless-Demo-Java/app/src/main/java/it/slyce/slycesdk_headless_demo_java/CameraActivity.java
+++ b/Examples/Headless/SlyceSDK-Headless-Demo-Java/app/src/main/java/it/slyce/slycesdk_headless_demo_java/CameraActivity.java
@@ -48,17 +48,7 @@ public class CameraActivity extends AppCompatActivity implements CameraResultDis
 
             // If camera permission has not been granted, request it.
             ActivityCompat.requestPermissions(this, REQUIRED_PERMISSIONS, PERMISSION_REQUEST_CODE);
-        } else {
-
-            // If camera permission has been granted, start the camera preview.
-            cameraSurfaceView.startCameraPreview();
         }
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        cameraSurfaceView.stopCameraPreview();
     }
 
     @Override


### PR DESCRIPTION
Removed calls to start and stop the camera preview in the onResume() and onPause() methods of the CameraActivity as they were redundant and could cause issues with attempting to release the camera twice.  The calls to start and stop the preview are still performed in the onSurfaceCrated() and onSurfaceDestroyed() methods of the CameraSurfaceView.